### PR TITLE
Resizable panels

### DIFF
--- a/app.R
+++ b/app.R
@@ -2,6 +2,7 @@ library(shiny)
 library(shinydashboard)
 library(shinyWidgets)
 library(shinyjs)
+library(shinyjqui)
 library(leaflet)
 library(sf)
 library(tidyr)
@@ -66,7 +67,7 @@ basemap <- leaflet(data = cams, options = leafletOptions(minZoom = ZOOM_MIN, max
   setView(lng = SURREY_LNG, lat = SURREY_LAT, zoom = (ZOOM_MIN+ZOOM_MAX)/2) %>%
   addMarkers(~longitude, ~latitude, layerId = ~as.character(station_name), label = ~as.character(station_name), icon = camIcon) %>%
   addProviderTiles(providers$CartoDB.Positron)%>%
-  addLegend("topleft",
+  leaflet::addLegend("topleft",
             colors = BIKE_COLOR_LEGEND,
             labels= BIKE_LABELS,
             title= "Bike Lane Type",
@@ -189,23 +190,25 @@ ui <- dashboardPage(
                   tags$head(includeCSS("styles.css")),
                   leafletOutput("basemap", width = "100%", height = "100%"),
                   absolutePanel(id = "controls", class = "panel panel-default", fixed = TRUE,
-                                draggable = TRUE, top = 60, left = "auto", right = 20, bottom = "auto",
-                                width = 500, height = "auto",
+                                draggable = TRUE, top = 60, left = "auto", right = 60, bottom = "auto",
+                                width = "fit-content", height = "auto",
                                 box(
                                   title = "Traffic Explorer",
                                   materialSwitch("weekdayOnly", label = "Weekdays Only", status = "primary", inline = TRUE, value = FALSE),
                                   materialSwitch("displayCorrection", label = "Correct for Undercount", status = "primary", inline = TRUE, value = FALSE),
-                                  plotOutput("linePlotVehicleCounts", height = "200"),
+                                  jqui_resizable(plotOutput("linePlotVehicleCounts", height = "200")),
                                   collapsible = T,
-                                  width = "100%", height = "auto"
-                                ),
-                                box(
-                                  title = "AM VS PM Biases (car count ONLY)",
+                                  width = "fit-content", height = "auto"
+                                )),
+                  absolutePanel(id = "controls", class = "panel panel-default", fixed = TRUE,
+                                draggable = TRUE, top = 400, left = "auto", right = 60, bottom = "auto",
+                                width = "fit-content", height = "auto",
+                                jqui_resizable(box(
+                                  title = "AM VS PM Biases (car count ONLY) long long test long long ",
                                   DT::dataTableOutput("ampmPairTable"),
                                   collapsible = T,
-                                  width = "100%", height = "auto"
-                                )
-                                )
+                                  width = "300px", height = "auto"
+                                )))
                   ),
               absolutePanel(id = "camera_img",
                             draggable = TRUE, top = "auto", left = "auto" , right = "auto", bottom = 20,

--- a/styles.css
+++ b/styles.css
@@ -63,3 +63,7 @@ img {
     max-width: 100%;
     max-height: 100%;
 }
+
+.box-title {
+    padding-right: 30px;
+}


### PR DESCRIPTION
<img width="1236" alt="image" src="https://user-images.githubusercontent.com/17880059/127549157-948752b8-5bb1-44e5-9a73-db0e44866eb3.png">

The panels can now be resized by mouse drag-and-drop using right bottom corner.
Closing #68 